### PR TITLE
webscraper bugfix where tournaments in <a> tags are missing

### DIFF
--- a/python/match_scores.py
+++ b/python/match_scores.py
@@ -47,6 +47,13 @@ def scrape_year(year):
     tourney_title_xpath = "//span[contains(@class, 'tourney-title')]/text()"
     tourney_title_parsed = xpath_parse(year_tree, tourney_title_xpath)
     tourney_title_cleaned = regex_strip_array(tourney_title_parsed)
+
+    # If tournament not found in <span> tags try find in <a> tags
+    if len(tourney_title_cleaned) == 0:
+        tourney_titles_xpath = "//a[contains(@class, 'tourney-title')]/text()"
+        tourney_titles_parsed = xpath_parse(year_tree, tourney_titles_xpath)
+        tourney_title_cleaned = regex_strip_array(tourney_titles_parsed)
+
     tourney_count = len(tourney_title_cleaned)
 
     # Iterate over each tournament
@@ -76,8 +83,8 @@ def scrape_year(year):
             tourney_year_id = ''
             tourney_urls.append(tourney_url_suffix)
             problem_tourneys.append([year, tourney_order, tourney_name])
-        
-        # Store data        
+
+        # Store data
         tourney_data.append([tourney_year_id, tourney_order, tourney_name, tourney_slug, tourney_url_suffix])
 
     # Print missing info
@@ -113,7 +120,7 @@ def scrape_tourney(tourney_url_suffix):
     tourney_id = url_split[7]
 
     # Tourney tree
-    tourney_tree = html_parse_tree(tourney_url)     
+    tourney_tree = html_parse_tree(tourney_url)
 
     tourney_round_name_xpath = "//table[contains(@class, 'day-table')]/thead/tr/th/text()"
     tourney_round_name_parsed = xpath_parse(tourney_tree, tourney_round_name_xpath)
@@ -145,19 +152,19 @@ def scrape_tourney(tourney_url_suffix):
         end_month = ''
         end_day = ''
 
-    # Prize money    
+    # Prize money
     prize_money_xpath = "//td[contains(@class, 'prize-money')]/div[2]/div/span/text()"
     prize_money_parsed = xpath_parse(tourney_tree, prize_money_xpath)
     prize_money_cleaned = regex_strip_array(prize_money_parsed)
 
-    if len(prize_money_cleaned) == 0 or prize_money_cleaned[0] == '': 
+    if len(prize_money_cleaned) == 0 or prize_money_cleaned[0] == '':
         prize_money_raw = ''
         prize_money = ''
         currency = ''
 
     elif len(prize_money_cleaned) > 0:
         prize_money_raw = prize_money_cleaned[0]
-        
+
         if tourney_id == '319' or tourney_id == '306':
             prize_money = prize_money_raw.replace(',', '')
             prize_money = int(re.findall('\d+', prize_money)[0])
@@ -174,14 +181,14 @@ def scrape_tourney(tourney_url_suffix):
             prize_money = prize_money.replace('£', '')
             prize_money = prize_money.replace('€', '')
             prize_money = prize_money.replace('A', '')
-            prize_money = int(prize_money)            
+            prize_money = int(prize_money)
 
-    else: 
+    else:
         prize_money_raw = 'PROBLEM'
         prize_money = ''
         currency = ''
 
-    # Iterate through each round   
+    # Iterate through each round
     match_urls = []
     match_data = []
     for i in range(0, tourney_round_count):
@@ -211,7 +218,7 @@ def scrape_tourney(tourney_url_suffix):
             winner_url = winner_url_parsed[0]
             winner_url_split = winner_url.split('/')
             winner_slug = winner_url_split[3]
-            winner_player_id = winner_url_split[4]      
+            winner_player_id = winner_url_split[4]
 
             # Loser
             loser_name_xpath = "//table[contains(@class, 'day-table')]/tbody[" + str(i + 1) + "]/tr[" + str(j + 1) + "]/td[contains(@class, 'day-table-name')][2]/a/text()"
@@ -244,8 +251,8 @@ def scrape_tourney(tourney_url_suffix):
                 winner_seed = ''
             winner_seed = winner_seed.replace('(', '')
             winner_seed = winner_seed.replace(')', '')
-            
-            loser_seed_xpath = "//table[contains(@class, 'day-table')]/tbody[" + str(i + 1) + "]/tr[" + str(j + 1) + "]/td[contains(@class, 'day-table-seed')][2]/span/text()"        
+
+            loser_seed_xpath = "//table[contains(@class, 'day-table')]/tbody[" + str(i + 1) + "]/tr[" + str(j + 1) + "]/td[contains(@class, 'day-table-seed')][2]/span/text()"
             loser_seed_parsed = xpath_parse(tourney_tree, loser_seed_xpath)
             loser_seed_cleaned = regex_strip_array(loser_seed_parsed)
             if len(loser_seed_cleaned) > 0:
@@ -253,14 +260,14 @@ def scrape_tourney(tourney_url_suffix):
             else:
                 loser_seed = ''
             loser_seed = loser_seed.replace('(', '')
-            loser_seed = loser_seed.replace(')', '')        
+            loser_seed = loser_seed.replace(')', '')
 
             # Match score
             match_score_text_xpath = "//table[contains(@class, 'day-table')]/tbody[" + str(i + 1) + "]/tr[" + str(j + 1) + "]/td[contains(@class, 'day-table-score')]/a/text()"
             match_score_text_parsed = xpath_parse(tourney_tree, match_score_text_xpath)
             if len(match_score_text_parsed) > 0:
                 if len(match_score_text_parsed) == 1:
-                    match_score_tiebreaks = '(W/O)' 
+                    match_score_tiebreaks = '(W/O)'
                     winner_sets_won = ''
                     loser_sets_won = ''
                     winner_games_won = ''
@@ -308,7 +315,7 @@ def scrape_tourney(tourney_url_suffix):
 
                     fix_concat_tiebreak_score = concat_tiebreak_score.replace("::[", "(")
                     fix_concat_tiebreak_score = fix_concat_tiebreak_score.replace("]::", ") ")
-                    fix_concat_tiebreak_score = fix_concat_tiebreak_score.replace("]", ")")    
+                    fix_concat_tiebreak_score = fix_concat_tiebreak_score.replace("]", ")")
                     tiebreak_score = fix_concat_tiebreak_score.split('::')
 
                     #match_score = match_score[0].strip()
@@ -365,7 +372,7 @@ def scrape_tourney(tourney_url_suffix):
                                 loser_sets_won += 1
                                 winner_games_won += int(sets[0:2])
                                 loser_games_won += int(sets[2:4])
-                                        
+
                 # Match stats URL
                 match_stats_url_xpath = tourney_match_count_xpath = "//table[contains(@class, 'day-table')]/tbody[" + str(i + 1) + "]/tr[" + str(j + 1) + "]/td[contains(@class, 'day-table-score')]/a/@href"
                 match_stats_url_parsed = xpath_parse(tourney_tree, match_stats_url_xpath)
@@ -374,7 +381,7 @@ def scrape_tourney(tourney_url_suffix):
                     if len(element) > 0: match_stats_url_cleaned.append(regex_strip_string(element))
                     #else: match_stats_url_cleaned.append("TIEBREAK")
 
-                # Match id                
+                # Match id
                 if len(match_stats_url_cleaned) > 0:
                     match_stats_url_suffix = match_stats_url_cleaned[0]
                     match_stats_url_suffix_split = match_stats_url_suffix.split('/')
@@ -387,7 +394,7 @@ def scrape_tourney(tourney_url_suffix):
 
                 # Store data
                 match_data.append([start_date, start_year, start_month, start_day, end_date, end_year, end_month, end_day, currency, prize_money, match_index, tourney_round_name, round_order, match_order, winner_name, winner_player_id, winner_slug, loser_name, loser_player_id, loser_slug, winner_seed, loser_seed, match_score_tiebreaks, winner_sets_won, loser_sets_won, winner_games_won, loser_games_won, winner_tiebreaks_won, loser_tiebreaks_won, match_id, match_stats_url_suffix])
-                #time.sleep(.100)       
+                #time.sleep(.100)
 
     output = [match_data, match_urls]
     return output
@@ -415,10 +422,10 @@ for h in range(int(start_year), int(end_year) + 1):
     print('Scraping match info for ' + str(len(tourney_urls_scrape)) + ' tournaments...')
     print('Year    Order    Tournament                                Matches')
     print('----    -----    ----------                                -------')
-    
+
     for i in range(0 , len(tourney_urls_scrape)):
         if len(tourney_urls_scrape[i]) > 0:
-            # STEP 2: Scrape tournament page    
+            # STEP 2: Scrape tournament page
             match_data_scrape = []
             match_urls_scrape = []
 
@@ -438,7 +445,7 @@ for h in range(int(start_year), int(end_year) + 1):
 
             spacing_count2 = 41 - len(tourney_data_scrape[i][2])
             spacing2 = ''
-            for j in range(0, spacing_count2): spacing2 += ' '            
+            for j in range(0, spacing_count2): spacing2 += ' '
 
             if len(match_data_scrape) == 0: print(year + '    ' + '\x1b[1;31m' + str(tourney_data_scrape[i][1]) + spacing1 + '    ' + tourney_data_scrape[i][2] + spacing2 + ' ' + str(len(match_data_scrape)) + '\x1b[0m')
             else: print(year + '    ' + str(tourney_data_scrape[i][1]) + spacing1 + '    ' + tourney_data_scrape[i][2] + spacing2 + ' ' + str(len(match_data_scrape)))

--- a/python/tournaments.py
+++ b/python/tournaments.py
@@ -48,13 +48,19 @@ def tournaments(year):
     tourney_titles_parsed = xpath_parse(year_tree, tourney_titles_xpath)
     tourney_titles_cleaned = regex_strip_array(tourney_titles_parsed)
 
+    # If no tournaments found in <span> tags try find in <a> tags
+    if len(tourney_titles_cleaned) == 0:
+        tourney_titles_xpath = "//a[contains(@class, 'tourney-title')]/text()"
+        tourney_titles_parsed = xpath_parse(year_tree, tourney_titles_xpath)
+        tourney_titles_cleaned = regex_strip_array(tourney_titles_parsed)
+
     tourney_count = len(tourney_titles_cleaned)
 
     # Iterate through each row in the tournaments table
     output = []
     for i in range(0, tourney_count):
         tourney_order = i + 1
-        
+
         # Tournament type
         tourney_type_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[2]/img[contains(@alt, 'tournament badge')]/@src"
         tourney_type_parsed = xpath_parse(year_tree, tourney_type_xpath)
@@ -77,6 +83,12 @@ def tournaments(year):
         tourney_info_parsed = xpath_parse(year_tree, tourney_info_xpath)
         tourney_info_cleaned = regex_strip_array(tourney_info_parsed)
 
+        # If tourney name not found in <span> tags try find in <a> tags
+        if len(tourney_info_cleaned) == 2:
+            tourney_info_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[3]/a/text()"
+            tourney_info_parsed = xpath_parse(year_tree, tourney_info_xpath)
+            tourney_info_cleaned = regex_strip_array(tourney_info_parsed) + tourney_info_cleaned
+
         #tourney_name = tourney_info_cleaned[0].encode('utf-8')
         tourney_name = tourney_info_cleaned[0]
         #tourney_location = tourney_info_cleaned[1].encode('utf-8')
@@ -97,13 +109,13 @@ def tournaments(year):
         tourney_singles_draw_parsed = xpath_parse(year_tree, tourney_singles_draw_xpath)
         tourney_singles_draw_cleaned = regex_strip_array(tourney_singles_draw_parsed)
         tourney_singles_draw = int(tourney_singles_draw_cleaned[0])
-        
+
         # Tournament doubles draw
         tourney_doubles_draw_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[4]/div/div[contains(., 'DBL')]/a[2]/span/text()"
         tourney_doubles_draw_parsed = xpath_parse(year_tree, tourney_doubles_draw_xpath)
         tourney_doubles_draw_cleaned = regex_strip_array(tourney_doubles_draw_parsed)
         tourney_doubles_draw = int(tourney_doubles_draw_cleaned[0])
-        
+
         # Tournament conditions
         tourney_conditions_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[5]/div/div[contains(., 'Outdoor') or contains(., 'Indoor')]/text()[normalize-space()]"
         tourney_conditions_parsed = xpath_parse(year_tree, tourney_conditions_xpath)
@@ -112,7 +124,7 @@ def tournaments(year):
             tourney_conditions = tourney_conditions_cleaned[0].strip()
         except Exception:
             tourney_conditions = ''
-        
+
         # Tourneament surface
         tourney_surface_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[5]/div/div[contains(., 'Outdoor') or contains(., 'Indoor')]/span/text()[normalize-space()]"
         tourney_surface_parsed = xpath_parse(year_tree, tourney_surface_xpath)
@@ -120,14 +132,14 @@ def tournaments(year):
         try:
             tourney_surface = tourney_surface_cleaned[0].strip()
         except Exception:
-            tourney_surface = ''                
+            tourney_surface = ''
 
         # Tournament total financial commitment
         tourney_fin_commit_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[6]/div/div/span/text()"
         tourney_fin_commit_parsed = xpath_parse(year_tree, tourney_fin_commit_xpath)
         tourney_fin_commit_cleaned = regex_strip_array(tourney_fin_commit_parsed)
-        
-        if len(tourney_fin_commit_cleaned) == 0: 
+
+        if len(tourney_fin_commit_cleaned) == 0:
             tourney_fin_commit_raw = ''
             tourney_fin_commit = ''
             currency = ''
@@ -148,14 +160,14 @@ def tournaments(year):
             tourney_fin_commit = tourney_fin_commit.replace('A','')
             tourney_fin_commit = int(tourney_fin_commit)
 
-        else: 
+        else:
             tourney_fin_commit_raw = 'PROBLEM'
             tourney_fin_commit = ''
             currency = ''
 
         # Tournament results
         tourney_details_url_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[8]/a/@href"
-        tourney_details_url_parsed = xpath_parse(year_tree, tourney_details_url_xpath)        
+        tourney_details_url_parsed = xpath_parse(year_tree, tourney_details_url_xpath)
 
         if len(tourney_details_url_parsed) > 0:
             tourney_url_suffix = tourney_details_url_parsed[0]
@@ -165,18 +177,18 @@ def tournaments(year):
         else:
             tourney_url_suffix = ''
             tourney_slug = ''
-            tourney_id = ''  
+            tourney_id = ''
 
         # Singles winner info
         singles_winner_name_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[7]/div[contains(., 'SGL:')]/a/text()"
         singles_winner_name_parsed = xpath_parse(year_tree, singles_winner_name_xpath)
         singles_winner_name_cleaned = regex_strip_array(singles_winner_name_parsed)
 
-        if len(singles_winner_name_cleaned) > 0: 
+        if len(singles_winner_name_cleaned) > 0:
             singles_winner_name = singles_winner_name_cleaned[0]
             singles_winner_url_xpath = "//tr[@class = 'tourney-result'][" + str(i + 1) + "]/td/div[contains(., 'SGL:')]/a/@href"
             singles_winner_url_parsed = xpath_parse(year_tree, singles_winner_url_xpath)
-            if len(singles_winner_url_parsed) > 0: 
+            if len(singles_winner_url_parsed) > 0:
                 singles_winner_url = singles_winner_url_parsed[0]
                 singles_winner_url_split = singles_winner_url.split('/')
                 singles_winner_player_slug = singles_winner_url_split[3]
@@ -184,7 +196,7 @@ def tournaments(year):
             else:
                 singles_winner_url = ''
                 singles_winner_player_slug = ''
-                singles_winner_player_id = ''            
+                singles_winner_player_id = ''
         else: # Case where tourney missing winner name but has a tourney URL
             if tourney_url_suffix != '':
                 # Check tourney URL for Finals match winner
@@ -200,23 +212,23 @@ def tournaments(year):
                     singles_winner_url = missing_winner_url_parsed[0]
                     singles_winner_url_split = singles_winner_url.split('/')
                     singles_winner_player_slug = singles_winner_url_split[3]
-                    singles_winner_player_id = singles_winner_url_split[4]                    
+                    singles_winner_player_id = singles_winner_url_split[4]
                 else:
                     singles_winner_url = ''
                     singles_winner_player_slug = ''
-                    singles_winner_player_id = ''          
+                    singles_winner_player_id = ''
             else: # Case where tourney is missing URL
                 singles_winner_name = ''
                 singles_winner_url = ''
                 singles_winner_player_slug = ''
-                singles_winner_player_id = '' 
+                singles_winner_player_id = ''
 
         # Doubles winners info
         doubles_winners_name_xpath = "//tr[contains(@class, 'tourney-result')][" + str(i + 1) + "]/td[7]/div[contains(., 'DBL:')]/a/text()"
         doubles_winners_name_parsed = xpath_parse(year_tree, doubles_winners_name_xpath)
         doubles_winners_name_cleaned = regex_strip_array(doubles_winners_name_parsed)
 
-        
+
         if len(doubles_winners_name_cleaned) == 2:
             doubles_winner_1_name = doubles_winners_name_cleaned[0]
             doubles_winner_2_name = doubles_winners_name_cleaned[1]
@@ -248,8 +260,8 @@ def tournaments(year):
 
             doubles_winner_2_url = ''
             doubles_winner_2_player_slug = ''
-            doubles_winner_2_player_id = ''   
-                                    
+            doubles_winner_2_player_id = ''
+
         else:
             doubles_winner_1_url = ''
             doubles_winner_1_player_slug = ''
@@ -257,15 +269,15 @@ def tournaments(year):
 
             doubles_winner_2_url = ''
             doubles_winner_2_player_slug = ''
-            doubles_winner_2_player_id = ''   
-        
+            doubles_winner_2_player_id = ''
+
         # Store data
         tourney_year_id = str(year) + '-' + tourney_id
         output.append([tourney_year_id, tourney_order, tourney_type, tourney_name, tourney_id, tourney_slug, tourney_location, tourney_date, year, tourney_month, tourney_day, tourney_singles_draw, tourney_doubles_draw, tourney_conditions, tourney_surface, tourney_fin_commit_raw, currency, tourney_fin_commit, tourney_url_suffix, singles_winner_name, singles_winner_url, singles_winner_player_slug, singles_winner_player_id, doubles_winner_1_name, doubles_winner_1_url, doubles_winner_1_player_slug, doubles_winner_1_player_id, doubles_winner_2_name, doubles_winner_2_url, doubles_winner_2_player_slug, doubles_winner_2_player_id])
-    
+
     # Output progress
     print(year + '    ' + str(tourney_count))
-    
+
     # Output data
     return output
 


### PR DESCRIPTION
Fixes bug in tournaments.py and match_scores.py where tournaments in the current year are not getting picked up. This is due to the tournament names being in <a> html tags rather than <span> html tags.